### PR TITLE
Use wrapper say function for error catch message

### DIFF
--- a/bot_modules/irc_bot.js
+++ b/bot_modules/irc_bot.js
@@ -142,7 +142,7 @@ command_parser = function(from, to, text, info) {
 		try {
 			var response = commands[command](info, words);
 		} catch(err) {
-			bot.say(info.channel, 'an error hath occured :X');
+			module.exports.say(info.channel, 'an error hath occured :X');
 			console.log(err);
 		}
 	}


### PR DESCRIPTION
Otherwise we get no colors: `bot.say` in irc_bot.js != `bot.say` in irc_commands.js.
