### PR TITLE
Handle additional aspects of IRC client

### DIFF
--- a/bot_modules/irc_bot.js
+++ b/bot_modules/irc_bot.js
@@ -181,6 +181,8 @@ module.exports = {
 
 	initialize: function() {
 		bot = new irc.Client(config.irc.server, config.bot_name, {
+			userName: config.bot_name.toLowerCase(),
+			realName: config.bot_name + ' IRC bot',
 			debug: config.irc.debug,
 			autoRejoin: config.irc.autoRejoin,
 			channels: config.irc.channels

--- a/bot_modules/irc_bot.js
+++ b/bot_modules/irc_bot.js
@@ -188,6 +188,10 @@ module.exports = {
 		commands = require('./irc_commands.js');
 
 
+		bot.addListener('error', function(message) {
+			console.log('IRC error: ' + message);
+		});
+
 		bot.addListener('join', function(channel, who) {
 			console.log(who + ' has joined ' + channel);
 		});

--- a/bot_modules/irc_bot.js
+++ b/bot_modules/irc_bot.js
@@ -181,6 +181,8 @@ module.exports = {
 
 	initialize: function() {
 		bot = new irc.Client(config.irc.server, config.bot_name, {
+			debug: config.irc.debug,
+			autoRejoin: config.irc.autoRejoin,
 			channels: config.irc.channels
 		});
 


### PR DESCRIPTION
Two config options were not passed to the client, and [a missing listener could possibly result in a crash](https://github.com/martynsmith/node-irc#help---it-keeps-crashing). Also set userName and realName for #25.
