### PR TITLE
add xhb alerts

### DIFF
--- a/bot_modules/http_server.js
+++ b/bot_modules/http_server.js
@@ -2,11 +2,12 @@ var config = require('./config.js')
 var ram = require('./memory.js')
 var http = require('http')
 var bot = require('./irc_bot.js')
-
+var alerts = require('./irc_alerts.js')
 
 var commands = {
 
 	say: message => {
+		alerts.setXHBTimeouts(); // update XHB alerts
 		console.log('SAY FROM SITE :: ' + message);
 		bot.say(config.irc.channels[0], message);
 		return 'the bot speaks!';
@@ -47,6 +48,8 @@ var respond = (response, code, content, message) => {
 module.exports = {
 
 	initialize: () => {
+		alerts.setXHBTimeouts();
+		setInterval(alerts.setXHBTimeouts, 5 * 60 * 1000);
 
 		http.createServer((request, response) => {
 			console.log(`SERVER REQUEST ::  ${request.method} ${request.url}`)

--- a/bot_modules/http_server.js
+++ b/bot_modules/http_server.js
@@ -48,7 +48,8 @@ var respond = (response, code, content, message) => {
 module.exports = {
 
 	initialize: () => {
-		alerts.setXHBTimeouts();
+		// wait until bot joins IRC, hopefully it's done so in 30 seconds
+		setTimeout(alerts.setXHBTimeouts, 30000);
 		setInterval(alerts.setXHBTimeouts, 5 * 60 * 1000);
 
 		http.createServer((request, response) => {

--- a/bot_modules/irc_alerts.js
+++ b/bot_modules/irc_alerts.js
@@ -1,0 +1,183 @@
+/*
+ * irc_alerts.js --
+ * throws messages in IRC when
+ * - it is 15 minutes before an XHB start;
+ * - an XHB has started;
+ * - it is 30, 10 or 2 minutes before XHB end;
+ * - when an XHB ends, and voting begins
+ */
+
+var https = require('https')
+var querystring = require('querystring')
+var request = require('request')
+
+var bot = require('./irc_bot.js')
+var commands = require('./irc_commands.js')
+var botb_api = require('./botb_api.js')
+var config = require('./config.js')
+
+// keep track of all timeout ids
+let timeouts = [];
+let alertChannel = config.irc.channels[0];
+let preAlertTime = 9e5; // 15 minutes in ms
+
+// discord role ping string, used at xhb pre-alert
+let roleXHBr = "<@&864233546981179442>";
+
+let battleAlerts = {};
+
+// contains functions that throw XHB announcement messages to the channel
+let announce = {
+  // when XHB starts
+  XHBStart: battle => {
+    battleAlerts[battle.id].start = true;
+
+    let allFormats = battle.format_tokens.join(", "); // just in case XHBs contain multiple formats in future
+    let announceString = `XHB :: ${battle.title} :: Format ${allFormats} :: started! g0g0g0g0g0! <${battle.profile_url.match(commands.url_regex)}>`;
+    bot.say(alertChannel, announceString);
+  },
+
+  // some minutes before XHB starts
+  XHBPre: (battle, startTime) => {
+    battleAlerts[battle.id].pre = true;
+
+    let minutes = Math.round((startTime / 1000) / 60);
+    let allFormats = battle.format_tokens.join(", ");
+    let announceString = `XHB :: ${battle.title} :: Format ${allFormats} :: will begin in ${minutes} minutes! ${roleXHBr}`;
+    bot.say(alertChannel, announceString);
+  },
+
+  // some minutes before XHB ends
+  XHBMinEnd: (battle, minutes) => {
+    switch (minutes) {
+      case 30:
+        battleAlerts[battle.id].end30 = true;
+        break;
+      case 10:
+        battleAlerts[battle.id].end10 = true;
+        break;
+      case 2:
+        battleAlerts[battle.id].end2 = true;
+        break;
+      default:
+        break;
+    }
+
+    let allFormats = battle.format_tokens.join(", ");
+    let announceString = `XHB :: ${battle.title} :: Format ${allFormats} :: ${minutes} minutes left!`;
+    bot.say(alertChannel, announceString);
+  },
+
+  // announce XHB end
+  XHBEnd: battle => {
+    battleAlerts[battle.id].end = true;
+
+    let allFormats = battle.format_tokens.join(", ");
+    let announceString = `XHB :: ${battle.title} :: Format ${allFormats} :: Time is teh up, slackerz.`;
+    bot.say(alertChannel, announceString);
+
+    // remove battle from battleAlerts
+    delete battleAlerts[battle.id];
+  }
+}
+
+let setXHBTimeouts = () => {
+  console.log("updating XHB timeouts!!");
+
+  botb_api.request("battle/current").then(data => {
+    // clear all the timeouts
+    if (timeouts.length > 0) {
+      for (timeout of timeouts) {
+        clearTimeout(timeout);
+      }
+    }
+
+    data.forEach(battle => {
+      if (battle.type === "3") {
+        // this is an XHB
+        if (battle.period === "vote") {
+          console.log(`battle ${battle.title} in voting phase, skipping...`);
+          return;
+        }
+
+        if (!battleAlerts.hasOwnProperty(battle.id)) {
+          // create object to track what alerts have been sent
+          battleAlerts[battle.id] = {
+            pre: false, start: false,
+            end30: false, end10: false, end2: false,
+            end: false
+          }
+        }
+
+        if (battle.period === "warmup") {
+          // XHB not yet started
+          // create timeout for when XHB begins, if we haven't alerted people yet
+          if (!battleAlerts[battle.id].start) {
+            timeouts.push(setTimeout(announce.XHBStart,
+                                     battle.period_end_seconds * 1000,
+                                     battle));
+            console.log(`waiting ${battle.period_end_seconds * 1000}ms until ${battle.title} begins...`);
+          }
+
+          // if we haven't alerted the peoples yet...
+          if (!battleAlerts[battle.id].pre) {
+            if (battle.period_end_seconds > (preAlertTime / 1000)) {
+              // create timeout for some time before XHB begins
+              timeouts.push(setTimeout(announce.XHBPre,
+                                       (battle.period_end_seconds * 1000) - preAlertTime,
+                                       battle, preAlertTime));
+              console.log(`waiting ${(battle.period_end_seconds * 1000) - preAlertTime}ms until pre-alert for ${battle.title} begins...`);
+            } else if (battle.period_end_seconds > 120) { // two mins minimum alert time
+              // alert them now!!
+              announce.XHBPre(battle, battle.period_end_seconds * 1000);
+              console.log(`${battle.title} begins now!`);
+            }
+          }
+        } else if (battle.period === "entry") {
+          // XHB started!
+
+          // alert at 30 minutes...
+          if (!battleAlerts[battle.id].end30) {
+            if ((battle.period_end_seconds * 1000) - 18e5 > 0) {
+              timeouts.push(setTimeout(announce.XHBMinEnd,
+                                       (battle.period_end_seconds * 1000) - 18e5,
+                                       battle, 30));
+              console.log(`waiting ${(battle.period_end_seconds * 1000) - 18e5}ms until 30min alert for ${battle.title}...`);
+            }
+          }
+          // alert at 10 minutes...
+          if (!battleAlerts[battle.id].end10) {
+            if ((battle.period_end_seconds * 1000) - 6e5 > 0) {
+              timeouts.push(setTimeout(announce.XHBMinEnd,
+                                       (battle.period_end_seconds * 1000) - 6e5,
+                                       battle, 10));
+              console.log(`waiting ${(battle.period_end_seconds * 1000) - 6e5}ms until 10min alert for ${battle.title}...`);
+            }
+          }
+          // alert at 2 minutes...
+          if (!battleAlerts[battle.id].end2) {
+            if ((battle.period_end_seconds * 1000) - 12e4 > 0) {
+              timeouts.push(setTimeout(announce.XHBMinEnd,
+                                       (battle.period_end_seconds * 1000) - 12e4,
+                                       battle, 2));
+              console.log(`waiting ${(battle.period_end_seconds * 1000) - 12e4}ms until 2min alert for ${battle.title}...`);
+            }
+          }
+          // alert at XHB end...
+          if (!battleAlerts[battle.id].end) {
+            timeouts.push(setTimeout(announce.XHBEnd,
+                                     (battle.period_end_seconds * 1000),
+                                     battle));
+            console.log(`waiting ${(battle.period_end_seconds * 1000)}ms until end alert for ${battle.title}...`);
+          }
+        }
+      }
+    });
+  }, error => {
+    return 1; // there are no battles!
+  });
+};
+
+module.exports = {
+  setXHBTimeouts: setXHBTimeouts
+}

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -32,7 +32,7 @@ function battle_data_to_response(data) {
 
 
 module.exports = {
-
+	url_regex: url_regex,
 	/**
 	 *	battle
 	 *


### PR DESCRIPTION
closes #2 
adds xhb alerts 15 minutes before xhb start (should ping the XHBr role but i haven't tested it so it might not work)
adds an alert when xhb starts
adds an alert 30, 10 and 2 minutes before xhb end
adds an alert when xhb ends

new module in `irc_alerts.js`, exposes function `setXHBTimeouts` which pulls battle data from the BotB API, clears all running timeouts, gets all XHBs that are not in voting phase and sets all appropriate timeouts which are calculated from `period_end_seconds`. it's kinda hard coded but i doubt we're going to be changing the periods when xhb alerts happen anyway so it's probably good enough.

`setXHBTimeouts` is called when the bot server initialises, when the bot receives a POST request to run the `say` command and every 5 minutes set by an interval.

PS: i hate tabs