### PR TITLE
add exact time when the battle starts + timezones

### DIFF
--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -409,13 +409,13 @@ module.exports = {
 			    if (current.getUTCHours() + hours > 23) hours -= 24;
 				let ohb_info = "OHB \"" + battle.title + "\" :: ";
 				if (timezone == "") {
-				    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours) + ":" + (current.getUTCMinutes() + minutes) + ")";
-				    if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours) + ":" + (current.getUTCMinutes() + minutes) + ")";
+				    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + "(" + (current.getUTCHours() + hours) + ":" + (current.getUTCMinutes() + minutes) + ")";
+				    if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + "(" + (current.getUTCHours() + hours) + ":" + (current.getUTCMinutes() + minutes) + ")";
 				}
 				if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
 				    let addToDate = parseInt(timezone.slice(3))
-				    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours + addToDate) + ":" + (current.getUTCMinutes() + minutes) + ")";
-				    if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours + addToDate) + ":" + (current.getUTCMinutes() + minutes) + ")";
+				    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + "(" + (current.getUTCHours() + hours + addToDate) + ":" + (current.getUTCMinutes() + minutes) + ")";
+				    if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + "(" + (current.getUTCHours() + hours + addToDate) + ":" + (current.getUTCMinutes() + minutes) + ")";
 				}
 				if (battle.period == 'vote') ohb_info += "Vorting Tiem";
 				ohb_info += " :: Format: " + battle.format_tokens[0];

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -387,7 +387,6 @@ module.exports = {
 		})
 	},
 
-	ohb: (info, words) => {
 		ohb: (info, words) => {
 		botb_api.request('battle/current').then(data => {
 			data = data.filter(battle => parseInt(battle.type) === 3)
@@ -405,13 +404,13 @@ module.exports = {
 				let ohb_info = "OHB \"" + battle.title + "\" :: ";
 				
 				if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
-				    if (timezone.slice(3) != "") {hours += parseInt(timezone.slice(3))};
+				    	if (timezone.slice(3) != "") {hours += parseInt(timezone.slice(3))};
 				}
 				
 				switch (timezone) {
 				    	case "pdt":
 				    	case "pacific us":
-				        	hours -= 7;
+				       		hours -= 7;
 				    	case "mdt":
 				    	case "mountain us":
 				        	hours -= 6;
@@ -458,11 +457,18 @@ module.exports = {
 			    	while (hours > 23) hours -= 24;
 			    	while (hours < 0) hours += 24;
 			    
+			    	if (hours >= 12) {var hours_am_pm = " PM"}
+			    	else if (hours < 12) {var hours_am_pm = " AM"};
+			    
+			    	if (hours == 0 || hours == 12) {var hours_am_pm_time = 12}
+			    	else if (hours > 12) {var hours_am_pm_time = hours - 12}
+			    	else {var hours_am_pm_time = hours};
+			    
 			    	if (hours.toString().length === 1) {hours = "0" + hours};
 			    	if (minutes.toString().length === 1) {minutes = "0" + minutes};
 			    
-			    	if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + " (" + (hours) + ":" + (minutes) + ")";
-				if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + " (" + (hours) + ":" + (minutes) + ")";
+			    	if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + "(" + hours + ":" + minutes + "/" + hours_am_pm_time + ":" + minutes + hours_am_pm + ")";
+				if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + "(" + hours + ":" + minutes + "/" + hours_am_pm_time + ":" + minutes + hours_am_pm + ")";
 				if (battle.period == 'vote') ohb_info += "Vorting Tiem";
 				ohb_info += " :: Format: " + battle.format_tokens[0];
 				ohb_info += " :: <" + battle.profile_url.match(url_regex) + "> ";

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -403,7 +403,7 @@ module.exports = {
 			    
 			    	let ohb_info = "OHB \"" + battle.title + "\" :: ";
 				
-			    	if (timezone == "") {var addToDate = 0; console.log("addToDate defined")}
+			    	if (timezone == "") {var addToDate = 0;}
 			    	else if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
 					if (timezone.slice(3) == "") {var addToDate = 0}
 					else {var addToDate = parseInt(timezone.slice(3))};

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -390,33 +390,51 @@ module.exports = {
 	ohb: (info, words) => {
 		botb_api.request('battle/current').then(data => {
 			data = data.filter(battle => parseInt(battle.type) === 3)
-			let timezone = words.slice(1).join(" ");
+			let timezone = words.slice(1).join(" ").toLowerCase()
 			var current = new Date();
 			if (data.length === 0) throw "No ohb data returned!"
 			data.forEach(battle => {
-			    let times = battle.period_end_time_left.split(" ");
-			    let hours = parseInt(times[0].slice(0, -1));
-			    let minutes = parseInt(times[1].slice(0, -1));
-			    let seconds = parseInt(times[2].slice(0, -1));
-			    while (current.getUTCSeconds() + seconds > 59) {
-			        minutes += 1;
-			        seconds -= 60;
-			    };
-			    while (current.getUTCMinutes() + minutes > 59) {
+			    let times = battle.period_end_time_left.split(" ")
+			    let hours = parseInt(times[0].slice(0, -1))
+			    console.log(times[0])
+			    console.log(times[0].slice(-1))
+			    console.log(parseInt(times[0].slice(0, -1)))
+			    let minutes = parseInt(times[1].slice(0, -1))
+			    
+				let ohb_info = "OHB \"" + battle.title + "\" :: ";
+				
+				if (timezone == "") {var addToDate = 0; console.log("addToDate defined")}
+				else if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
+				    if (timezone.slice(3) == "") {var addToDate = 0}
+				    else {var addToDate = parseInt(timezone.slice(3))};
+				}
+				else if (timezone.startsWith("est")) {
+				    if (timezone.slice(3) == "") {var addToDate = -5}
+				    else {var addToDate = -5 + parseInt(timezone.slice(3))};
+				}
+				else if (timezone.startsWith("edt") || timezone.startsWith("et")) {
+				    if (timezone.slice(3) == "") {var addToDate = -4}
+				    else {var addToDate = -4 + parseInt(timezone.slice(3))};
+				}
+				else if (timezone.startsWith("cet") || timezone.startsWith("cest")) {
+				    if (timezone.slice(3) == "") {var addToDate = 1}
+				    else {var addToDate = 1 + parseInt(timezone.slice(3))};
+				};
+				
+				hours += addToDate + current.getUTCHours();
+				minutes += addToDate + current.getUTCMinutes();
+			    while (minutes > 59) {
 			        hours += 1;
 			        minutes -= 60;
 			    };
-			    if (current.getUTCHours() + hours > 23) hours -= 24;
-				let ohb_info = "OHB \"" + battle.title + "\" :: ";
-				if (timezone == "") {
-				    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + "(" + (current.getUTCHours() + hours) + ":" + (current.getUTCMinutes() + minutes) + ")";
-				    if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + "(" + (current.getUTCHours() + hours) + ":" + (current.getUTCMinutes() + minutes) + ")";
-				}
-				if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
-				    let addToDate = parseInt(timezone.slice(3))
-				    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + "(" + (current.getUTCHours() + hours + addToDate) + ":" + (current.getUTCMinutes() + minutes) + ")";
-				    if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + "(" + (current.getUTCHours() + hours + addToDate) + ":" + (current.getUTCMinutes() + minutes) + ")";
-				}
+			    if (hours > 23) hours -= 24;
+			    if (hours < 0) hours += 24;
+			    
+			    if (hours.toString().length === 1) {hours = "0" + hours};
+			    if (minutes.toString().length === 1) {minutes = "0" + minutes};
+			    
+			    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + " (" + (hours) + ":" + (minutes) + ")";
+				if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + " (" + (hours) + ":" + (minutes) + ")";
 				if (battle.period == 'vote') ohb_info += "Vorting Tiem";
 				ohb_info += " :: Format: " + battle.format_tokens[0];
 				ohb_info += " :: <" + battle.profile_url.match(url_regex) + "> ";

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -394,46 +394,46 @@ module.exports = {
 			var current = new Date();
 			if (data.length === 0) throw "No ohb data returned!"
 			data.forEach(battle => {
-			    let times = battle.period_end_time_left.split(" ")
-			    let hours = parseInt(times[0].slice(0, -1))
-			    console.log(times[0])
-			    console.log(times[0].slice(-1))
-			    console.log(parseInt(times[0].slice(0, -1)))
-			    let minutes = parseInt(times[1].slice(0, -1))
+				let times = battle.period_end_time_left.split(" ")
+				let hours = parseInt(times[0].slice(0, -1))
+				console.log(times[0])
+				console.log(times[0].slice(-1))
+				console.log(parseInt(times[0].slice(0, -1)))
+			    	let minutes = parseInt(times[1].slice(0, -1))
 			    
-			    let ohb_info = "OHB \"" + battle.title + "\" :: ";
+			    	let ohb_info = "OHB \"" + battle.title + "\" :: ";
 				
-			    if (timezone == "") {var addToDate = 0; console.log("addToDate defined")}
-			    else if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
-				if (timezone.slice(3) == "") {var addToDate = 0}
-				else {var addToDate = parseInt(timezone.slice(3))};
-		            }
-			    else if (timezone.startsWith("est")) {
-				if (timezone.slice(3) == "") {var addToDate = -5}
-				else {var addToDate = -5 + parseInt(timezone.slice(3))};
-			    }
-			    else if (timezone.startsWith("edt") || timezone.startsWith("et")) {
-				if (timezone.slice(3) == "") {var addToDate = -4}
-				else {var addToDate = -4 + parseInt(timezone.slice(3))};
-			    }
-			    else if (timezone.startsWith("cet") || timezone.startsWith("cest")) {
-				if (timezone.slice(3) == "") {var addToDate = 1}
-				else {var addToDate = 1 + parseInt(timezone.slice(3))};
-			    };
+			    	if (timezone == "") {var addToDate = 0; console.log("addToDate defined")}
+			    	else if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
+					if (timezone.slice(3) == "") {var addToDate = 0}
+					else {var addToDate = parseInt(timezone.slice(3))};
+		            	}
+			    	else if (timezone.startsWith("est")) {
+					if (timezone.slice(3) == "") {var addToDate = -5}
+					else {var addToDate = -5 + parseInt(timezone.slice(3))};
+			    	}
+			    	else if (timezone.startsWith("edt") || timezone.startsWith("et")) {
+					if (timezone.slice(3) == "") {var addToDate = -4}
+					else {var addToDate = -4 + parseInt(timezone.slice(3))};
+			    	}
+			    	else if (timezone.startsWith("cet") || timezone.startsWith("cest")) {
+					if (timezone.slice(3) == "") {var addToDate = 1}
+					else {var addToDate = 1 + parseInt(timezone.slice(3))};
+			    	};
 				
-			    hours += addToDate + current.getUTCHours();
-			    minutes += addToDate + current.getUTCMinutes();
-			    while (minutes > 59) {
-			        hours += 1;
-			        minutes -= 60;
-			    };
-			    if (hours > 23) hours -= 24;
-			    if (hours < 0) hours += 24;
+			    	hours += addToDate + current.getUTCHours();
+			    	minutes += addToDate + current.getUTCMinutes();
+			    	while (minutes > 59) {
+			        	hours += 1;
+			        	minutes -= 60;
+			    	};
+			    	if (hours > 23) hours -= 24;
+			    	if (hours < 0) hours += 24;
 			    
-			    if (hours.toString().length === 1) {hours = "0" + hours};
-			    if (minutes.toString().length === 1) {minutes = "0" + minutes};
+			    	if (hours.toString().length === 1) {hours = "0" + hours};
+			    	if (minutes.toString().length === 1) {minutes = "0" + minutes};
 			    
-			    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + " (" + (hours) + ":" + (minutes) + ")";
+			    	if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + " (" + (hours) + ":" + (minutes) + ")";
 				if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + " (" + (hours) + ":" + (minutes) + ")";
 				if (battle.period == 'vote') ohb_info += "Vorting Tiem";
 				ohb_info += " :: Format: " + battle.format_tokens[0];

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -390,11 +390,33 @@ module.exports = {
 	ohb: (info, words) => {
 		botb_api.request('battle/current').then(data => {
 			data = data.filter(battle => parseInt(battle.type) === 3)
+			let timezone = words.slice(1).join(" ");
+			var current = new Date();
 			if (data.length === 0) throw "No ohb data returned!"
 			data.forEach(battle => {
+			    let times = battle.period_end_time_left.split(" ");
+			    let hours = parseInt(times[0].slice(0, -1));
+			    let minutes = parseInt(times[1].slice(0, -1));
+			    let seconds = parseInt(times[2].slice(0, -1));
+			    while (current.getUTCSeconds() + seconds > 59) {
+			        minutes += 1;
+			        seconds -= 60;
+			    };
+			    while (current.getUTCMinutes() + minutes > 59) {
+			        hours += 1;
+			        minutes -= 60;
+			    };
+			    if (current.getUTCHours() + hours > 23) hours -= 24;
 				let ohb_info = "OHB \"" + battle.title + "\" :: ";
-				if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left;
-				if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left;
+				if (timezone == "") {
+				    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours) + ":" + (current.getUTCMinutes() + minutes) + ")";
+				    if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours) + ":" + (current.getUTCMinutes() + minutes) + ")";
+				}
+				if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
+				    let addToDate = parseInt(timezone.slice(3))
+				    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours + addToDate) + ":" + (current.getUTCMinutes() + minutes) + ")";
+				    if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours + addToDate) + ":" + (current.getUTCMinutes() + minutes) + ")";
+				}
 				if (battle.period == 'vote') ohb_info += "Vorting Tiem";
 				ohb_info += " :: Format: " + battle.format_tokens[0];
 				ohb_info += " :: <" + battle.profile_url.match(url_regex) + "> ";

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -388,47 +388,75 @@ module.exports = {
 	},
 
 	ohb: (info, words) => {
+		ohb: (info, words) => {
 		botb_api.request('battle/current').then(data => {
 			data = data.filter(battle => parseInt(battle.type) === 3)
 			let timezone = words.slice(1).join(" ").toLowerCase()
 			var current = new Date();
 			if (data.length === 0) throw "No ohb data returned!"
 			data.forEach(battle => {
-				let times = battle.period_end_time_left.split(" ")
-				let hours = parseInt(times[0].slice(0, -1))
-				console.log(times[0])
-				console.log(times[0].slice(-1))
-				console.log(parseInt(times[0].slice(0, -1)))
+			    	let times = battle.period_end_time_left.split(" ")
+			    	let hours = parseInt(times[0].slice(0, -1))
+			    	console.log(times[0])
+			    	console.log(times[0].slice(-1))
+			    	console.log(parseInt(times[0].slice(0, -1)))
 			    	let minutes = parseInt(times[1].slice(0, -1))
 			    
-			    	let ohb_info = "OHB \"" + battle.title + "\" :: ";
+				let ohb_info = "OHB \"" + battle.title + "\" :: ";
 				
-			    	if (timezone == "") {var addToDate = 0;}
-			    	else if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
-					if (timezone.slice(3) == "") {var addToDate = 0}
-					else {var addToDate = parseInt(timezone.slice(3))};
-		            	}
-			    	else if (timezone.startsWith("est")) {
-					if (timezone.slice(3) == "") {var addToDate = -5}
-					else {var addToDate = -5 + parseInt(timezone.slice(3))};
-			    	}
-			    	else if (timezone.startsWith("edt") || timezone.startsWith("et")) {
-					if (timezone.slice(3) == "") {var addToDate = -4}
-					else {var addToDate = -4 + parseInt(timezone.slice(3))};
-			    	}
-			    	else if (timezone.startsWith("cet") || timezone.startsWith("cest")) {
-					if (timezone.slice(3) == "") {var addToDate = 1}
-					else {var addToDate = 1 + parseInt(timezone.slice(3))};
-			    	};
+				if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
+				    if (timezone.slice(3) != "") {hours += parseInt(timezone.slice(3))};
+				}
 				
-			    	hours += addToDate + current.getUTCHours();
-			    	minutes += addToDate + current.getUTCMinutes();
+				switch (timezone) {
+				    	case "pdt":
+				    	case "pacific us":
+				        	hours -= 7;
+				    	case "mdt":
+				    	case "mountain us":
+				        	hours -= 6;
+				    	case "cdt":
+				    	case "central us":
+				        	hours -= 5;
+				    	case "edt":
+				    	case "eastern us":
+				        	hours -= 4;
+				    	case "bst":
+				    	case "uk":
+				        	hours += 1;
+				    	case "cest":
+				    	case "germany":
+				        	hours += 2;
+				    	case "msk":
+				    	case "russia":
+				        	hours += 3;
+				    	case "ist":
+				    	case "india":
+				        	hours += 5;
+				        	minutes += 30;
+				    	case "cst":
+				    	case "china":
+				        	hours += 8;
+				    	case "jst":
+				    	case "japan":
+				        	hours += 9;
+				    	case "aest":
+				    	case "australia":
+				        	hours += 10;
+				    	case "nzst":
+				    	case "new zealand":
+				        	hours += 12;
+				};
+				
+				hours += current.getUTCHours();
+				minutes += current.getUTCMinutes();
 			    	while (minutes > 59) {
 			        	hours += 1;
 			        	minutes -= 60;
 			    	};
-			    	if (hours > 23) hours -= 24;
-			    	if (hours < 0) hours += 24;
+			    
+			    	while (hours > 23) hours -= 24;
+			    	while (hours < 0) hours += 24;
 			    
 			    	if (hours.toString().length === 1) {hours = "0" + hours};
 			    	if (minutes.toString().length === 1) {minutes = "0" + minutes};

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -401,28 +401,28 @@ module.exports = {
 			    console.log(parseInt(times[0].slice(0, -1)))
 			    let minutes = parseInt(times[1].slice(0, -1))
 			    
-				let ohb_info = "OHB \"" + battle.title + "\" :: ";
+			    let ohb_info = "OHB \"" + battle.title + "\" :: ";
 				
-				if (timezone == "") {var addToDate = 0; console.log("addToDate defined")}
-				else if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
-				    if (timezone.slice(3) == "") {var addToDate = 0}
-				    else {var addToDate = parseInt(timezone.slice(3))};
-				}
-				else if (timezone.startsWith("est")) {
-				    if (timezone.slice(3) == "") {var addToDate = -5}
-				    else {var addToDate = -5 + parseInt(timezone.slice(3))};
-				}
-				else if (timezone.startsWith("edt") || timezone.startsWith("et")) {
-				    if (timezone.slice(3) == "") {var addToDate = -4}
-				    else {var addToDate = -4 + parseInt(timezone.slice(3))};
-				}
-				else if (timezone.startsWith("cet") || timezone.startsWith("cest")) {
-				    if (timezone.slice(3) == "") {var addToDate = 1}
-				    else {var addToDate = 1 + parseInt(timezone.slice(3))};
-				};
+			    if (timezone == "") {var addToDate = 0; console.log("addToDate defined")}
+			    else if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
+				if (timezone.slice(3) == "") {var addToDate = 0}
+				else {var addToDate = parseInt(timezone.slice(3))};
+		            }
+			    else if (timezone.startsWith("est")) {
+				if (timezone.slice(3) == "") {var addToDate = -5}
+				else {var addToDate = -5 + parseInt(timezone.slice(3))};
+			    }
+			    else if (timezone.startsWith("edt") || timezone.startsWith("et")) {
+				if (timezone.slice(3) == "") {var addToDate = -4}
+				else {var addToDate = -4 + parseInt(timezone.slice(3))};
+			    }
+			    else if (timezone.startsWith("cet") || timezone.startsWith("cest")) {
+				if (timezone.slice(3) == "") {var addToDate = 1}
+				else {var addToDate = 1 + parseInt(timezone.slice(3))};
+			    };
 				
-				hours += addToDate + current.getUTCHours();
-				minutes += addToDate + current.getUTCMinutes();
+			    hours += addToDate + current.getUTCHours();
+			    minutes += addToDate + current.getUTCMinutes();
 			    while (minutes > 59) {
 			        hours += 1;
 			        minutes -= 60;


### PR DESCRIPTION
Added time when the competition starts, along with timezone support.

Example:
```
<viraxor> !ohb
<BotB2_tes>  OHB "vav's lunchbreak xhb #29" :: Starting in: 12h 29m 17s (21:29) :: Format: wildchip :: <https://battleofthebits.org/arena/Battle/7082/>
<viraxor> !ohb gmt+1
<BotB2_tes>  OHB "vav's lunchbreak xhb #29" :: Starting in: 12h 28m 38s (22:29) :: Format: wildchip :: <https://battleofthebits.org/arena/Battle/7082/>  
<viraxor> !ohb utc-1
<BotB2_tes>  OHB "vav's lunchbreak xhb #29" :: Starting in: 12h 27m 25s (20:29) :: Format: wildchip :: <https://battleofthebits.org/arena/Battle/7082/>  
```