### PR TITLE
add basic rolling (again)

### DIFF
--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -394,29 +394,8 @@ module.exports = {
 			var current = new Date();
 			if (data.length === 0) throw "No ohb data returned!"
 			data.forEach(battle => {
-			    let times = battle.period_end_time_left.split(" ");
-			    let hours = parseInt(times[0].slice(0, -1));
-			    let minutes = parseInt(times[1].slice(0, -1));
-			    let seconds = parseInt(times[2].slice(0, -1));
-			    while (current.getUTCSeconds() + seconds > 59) {
-			        minutes += 1;
-			        seconds -= 60;
-			    };
-			    while (current.getUTCMinutes() + minutes > 59) {
-			        hours += 1;
-			        minutes -= 60;
-			    };
-			    if (current.getUTCHours() + hours > 23) hours -= 24;
-				let ohb_info = "OHB \"" + battle.title + "\" :: ";
-				if (timezone == "") {
-				    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours) + ":" + (current.getUTCMinutes() + minutes) + ")";
-				    if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours) + ":" + (current.getUTCMinutes() + minutes) + ")";
-				}
-				if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
-				    let addToDate = parseInt(timezone.slice(3))
-				    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours + addToDate) + ":" + (current.getUTCMinutes() + minutes) + ")";
-				    if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours + addToDate) + ":" + (current.getUTCMinutes() + minutes) + ")";
-				}
+				if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left);
+				if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left);
 				if (battle.period == 'vote') ohb_info += "Vorting Tiem";
 				ohb_info += " :: Format: " + battle.format_tokens[0];
 				ohb_info += " :: <" + battle.profile_url.match(url_regex) + "> ";

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -490,8 +490,6 @@ module.exports = {
 	roll: (info, words) => {
 		let dice_notation = words.slice(1).join(" ").toLowerCase();
 		if (dice_notation.includes("d")) {
-	   		if (dice_notation == "") dice_notation = "1d10";
-	        
 	   		if (dice_notation.startsWith("d")) {dice_notation = "1" + dice_notation; var dice_amount = 1}
 	   		else {var dice_amount = parseInt(dice_notation.split("d")[0])};
 	        

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -482,6 +482,18 @@ module.exports = {
 			})
 		})
 	},
+	
+	/**
+	 *	roll
+	 *
+	 */
+	
+	roll: (info, words) => {
+	    	let number = words.slice(1).join(" ");
+	    	if (number == "") number = 10;
+	    	let chat_text = `${info.from} rolls ` + (Math.floor(Math.random() * number) + 1) + "!"
+	    	bot.say(info.channel, `${chat_text}`)
+	},
 
 	/**
 	 *	ultrachord

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -490,20 +490,43 @@ module.exports = {
 	
 	roll: (info, words) => {
 	    	let dice_notation = words.slice(1).join(" ").toLowerCase();
-	    	if (dice_notation == "") dice_notation = "d10";
+	    	if (dice_notation == "") dice_notation = "1d10";
 	    
-	    	if (dice_notation.startsWith("d")) {var dice_amount = 1}
+	    	if (dice_notation.startsWith("d")) {dice_notation = "1" + dice_notation; var dice_amount = 1}
 	    	else {var dice_amount = parseInt(dice_notation.split("d")[0])};
 	    
 	    	let sum = 0;
 	    
-	    	let dice_amount_length = dice_amount.toString().length;
+	    	var dice_amount_length = dice_amount.toString().length + 1;
+	    
 	    	if (dice_notation.includes("+")) {
-	        	sum += parseInt(dice_notation.split("+")[1]);
+	        	let add_to_sum = dice_notation.split("+")[1];
+	        
+	        	if (add_to_sum.includes("d")) {
+	            		if (add_to_sum.startsWith("d")) add_to_sum = "1" + add_to_sum;
+	            		let subdice_amount = parseInt(add_to_sum.split("d")[0]);;
+	            		let subnumber_limit = parseInt(add_to_sum.split("d")[1]);
+	            		for (let i = 0; i < subdice_amount; i++) {sum += Math.floor(Math.random() * subnumber_limit) + 1};
+	        	}
+	        	else {
+	            		sum += parseInt(add_to_sum);
+	        	};
+	        
 	        	var number_limit = parseInt(dice_notation.split("+")[0].slice(dice_amount_length));
-	    	}	
+	    	}
 	    	else if (dice_notation.includes("-")) {
-	        	sum -= parseInt(dice_notation.split("-")[1]);
+	        	let subtract_to_sum = dice_notation.split("-")[1];
+	        
+	        	if (subtract_to_sum.includes("d")) {
+	            		if (subtract_to_sum.startsWith("d")) subtract_to_sum = "1" + subtract_to_sum;
+	            		let subdice_amount = parseInt(subtract_to_sum.split("d")[0]);
+	            		let subnumber_limit = parseInt(subtract_to_sum.split("d")[1]);
+	            		for (let i = 0; i < subdice_amount; i++) {sum -= Math.floor(Math.random() * subnumber_limit) + 1};
+	        	}
+	        	else {
+	            		sum += parseInt(subtract_to_sum);
+	        	};
+	        
 	        	var number_limit = parseInt(dice_notation.split("-")[0].slice(dice_amount_length));
 	    	}
 	    	else {

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -488,60 +488,60 @@ module.exports = {
 	 *
 	 */
 	roll: (info, words) => {
-	 let dice_notation = words.slice(1).join(" ").toLowerCase();
-	  if (dice_notation.includes("d")) {
-	   if (dice_notation == "") dice_notation = "1d10";
+		let dice_notation = words.slice(1).join(" ").toLowerCase();
+		if (dice_notation.includes("d")) {
+	   		if (dice_notation == "") dice_notation = "1d10";
 	        
-	   if (dice_notation.startsWith("d")) {dice_notation = "1" + dice_notation; var dice_amount = 1}
-	   else {var dice_amount = parseInt(dice_notation.split("d")[0])};
+	   		if (dice_notation.startsWith("d")) {dice_notation = "1" + dice_notation; var dice_amount = 1}
+	   		else {var dice_amount = parseInt(dice_notation.split("d")[0])};
 	        
-	   let sum = 0;
+	   		let sum = 0;
 	        
-	   var dice_amount_length = dice_amount.toString().length + 1;
+	   		var dice_amount_length = dice_amount.toString().length + 1;
 	        
-	   if (dice_notation.includes("+")) {
-	    let add_to_sum = dice_notation.split("+")[1];
+	  		if (dice_notation.includes("+")) {
+	    			let add_to_sum = dice_notation.split("+")[1];
 	            
-	    if (add_to_sum.includes("d")) {
-	     if (add_to_sum.startsWith("d")) add_to_sum = "1" + add_to_sum;
-	     let subdice_amount = parseInt(add_to_sum.split("d")[0]);;
-	     let subnumber_limit = parseInt(add_to_sum.split("d")[1]);
-	     for (let i = 0; i < subdice_amount; i++) {sum += Math.floor(Math.random() * subnumber_limit) + 1};
-	    }
-	    else {
-	     sum += parseInt(add_to_sum);
-	    };
+	    			if (add_to_sum.includes("d")) {
+	     				if (add_to_sum.startsWith("d")) add_to_sum = "1" + add_to_sum;
+	     				let subdice_amount = parseInt(add_to_sum.split("d")[0]);;
+	     				let subnumber_limit = parseInt(add_to_sum.split("d")[1]);
+	     				for (let i = 0; i < subdice_amount; i++) {sum += Math.floor(Math.random() * subnumber_limit) + 1};
+	    			}
+	    			else {
+	     				sum += parseInt(add_to_sum);
+	    			};
 	            
-	    var number_limit = parseInt(dice_notation.split("+")[0].slice(dice_amount_length));
-	   }
-	   else if (dice_notation.includes("-")) {
-	    let subtract_to_sum = dice_notation.split("-")[1];
+	    			var number_limit = parseInt(dice_notation.split("+")[0].slice(dice_amount_length));
+	   		}
+	   		else if (dice_notation.includes("-")) {
+	    			let subtract_to_sum = dice_notation.split("-")[1];
 	            
-	    if (subtract_to_sum.includes("d")) {
-	     if (subtract_to_sum.startsWith("d")) subtract_to_sum = "1" + subtract_to_sum;
-	     let subdice_amount = parseInt(subtract_to_sum.split("d")[0]);
-	     let subnumber_limit = parseInt(subtract_to_sum.split("d")[1]);
-	     for (let i = 0; i < subdice_amount; i++) {sum -= Math.floor(Math.random() * subnumber_limit) + 1};
-	    }
-	    else {
-	     sum += parseInt(subtract_to_sum);
-	    };
+	    			if (subtract_to_sum.includes("d")) {
+	     				if (subtract_to_sum.startsWith("d")) subtract_to_sum = "1" + subtract_to_sum;
+	     				let subdice_amount = parseInt(subtract_to_sum.split("d")[0]);
+	     				let subnumber_limit = parseInt(subtract_to_sum.split("d")[1]);
+	     				for (let i = 0; i < subdice_amount; i++) {sum -= Math.floor(Math.random() * subnumber_limit) + 1};
+	    			}
+	    		else {
+	     			sum += parseInt(subtract_to_sum);
+	    		};
 	            
-	    var number_limit = parseInt(dice_notation.split("-")[0].slice(dice_amount_length));
-	   }
-	   else {
-	    var number_limit = parseInt(dice_notation.slice(dice_amount_length));
-	   };
+	    		var number_limit = parseInt(dice_notation.split("-")[0].slice(dice_amount_length));
+	   		}
+	   		else {
+	    			var number_limit = parseInt(dice_notation.slice(dice_amount_length));
+	   		};
 	        
-	   for (let i = 0; i < dice_amount; i++) {sum += Math.floor(Math.random() * number_limit) + 1};
-	   var chat_text = `${info.from} rolls ` + sum + "!";
-	  }
-	  else {
-		 if (dice_notation == "") dice_notation = "10";
-	    var chat_text = `${info.from} rolls ` + (Math.floor(Math.random() * parseInt(dice_notation)) + 1) + "!";
-	   };
+	   		for (let i = 0; i < dice_amount; i++) {sum += Math.floor(Math.random() * number_limit) + 1};
+	   		var chat_text = `${info.from} rolls ` + sum + "!";
+	  	}
+	  	else {
+			if (dice_notation == "") dice_notation = "10";
+	    		var chat_text = `${info.from} rolls ` + (Math.floor(Math.random() * parseInt(dice_notation)) + 1) + "!";
+	   	};
 	    
-	 bot.say(info.channel, `${chat_text}`);
+	 	bot.say(info.channel, `${chat_text}`);
 	},
 
 	/**

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -390,12 +390,11 @@ module.exports = {
 	ohb: (info, words) => {
 		botb_api.request('battle/current').then(data => {
 			data = data.filter(battle => parseInt(battle.type) === 3)
-			let timezone = words.slice(1).join(" ");
-			var current = new Date();
 			if (data.length === 0) throw "No ohb data returned!"
 			data.forEach(battle => {
-				if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left);
-				if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left);
+				let ohb_info = "OHB \"" + battle.title + "\" :: ";
+				if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left;
+				if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left;
 				if (battle.period == 'vote') ohb_info += "Vorting Tiem";
 				ohb_info += " :: Format: " + battle.format_tokens[0];
 				ohb_info += " :: <" + battle.profile_url.match(url_regex) + "> ";

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -537,6 +537,7 @@ module.exports = {
 	        	var chat_text = `${info.from} rolls ` + sum + "!";
 	    	}
 	    	else {
+			if (dice_notation == "") dice_notation = "10";
 	    		var chat_text = `${info.from} rolls ` + (Math.floor(Math.random() * parseInt(dice_notation)) + 1) + "!";
 	    	};
 	    

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -482,62 +482,6 @@ module.exports = {
 			})
 		})
 	},
-	
-	/**
-	 *	roll
-	 *
-	 */
-	
-	roll: (info, words) => {
-	    	let dice_notation = words.slice(1).join(" ").toLowerCase();
-	    	if (dice_notation == "") dice_notation = "1d10";
-	    
-	    	if (dice_notation.startsWith("d")) {dice_notation = "1" + dice_notation; var dice_amount = 1}
-	    	else {var dice_amount = parseInt(dice_notation.split("d")[0])};
-	    
-	    	let sum = 0;
-	    
-	    	var dice_amount_length = dice_amount.toString().length + 1;
-	    
-	    	if (dice_notation.includes("+")) {
-	        	let add_to_sum = dice_notation.split("+")[1];
-	        
-	        	if (add_to_sum.includes("d")) {
-	            		if (add_to_sum.startsWith("d")) add_to_sum = "1" + add_to_sum;
-	            		let subdice_amount = parseInt(add_to_sum.split("d")[0]);;
-	            		let subnumber_limit = parseInt(add_to_sum.split("d")[1]);
-	            		for (let i = 0; i < subdice_amount; i++) {sum += Math.floor(Math.random() * subnumber_limit) + 1};
-	        	}
-	        	else {
-	            		sum += parseInt(add_to_sum);
-	        	};
-	        
-	        	var number_limit = parseInt(dice_notation.split("+")[0].slice(dice_amount_length));
-	    	}
-	    	else if (dice_notation.includes("-")) {
-	        	let subtract_to_sum = dice_notation.split("-")[1];
-	        
-	        	if (subtract_to_sum.includes("d")) {
-	            		if (subtract_to_sum.startsWith("d")) subtract_to_sum = "1" + subtract_to_sum;
-	            		let subdice_amount = parseInt(subtract_to_sum.split("d")[0]);
-	            		let subnumber_limit = parseInt(subtract_to_sum.split("d")[1]);
-	            		for (let i = 0; i < subdice_amount; i++) {sum -= Math.floor(Math.random() * subnumber_limit) + 1};
-	        	}
-	        	else {
-	            		sum += parseInt(subtract_to_sum);
-	        	};
-	        
-	        	var number_limit = parseInt(dice_notation.split("-")[0].slice(dice_amount_length));
-	    	}
-	    	else {
-	        	var number_limit = parseInt(dice_notation.slice(dice_amount_length));
-	    	};
-	    
-	    	for (let i = 0; i < dice_amount; i++) {sum += Math.floor(Math.random() * number_limit) + 1};
-	    	let chat_text = `${info.from} rolls ` + sum + "!";
-	    
-	    	bot.say(info.channel, `${chat_text}`);
-	},
 
 	/**
 	 *	ultrachord

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -390,11 +390,33 @@ module.exports = {
 	ohb: (info, words) => {
 		botb_api.request('battle/current').then(data => {
 			data = data.filter(battle => parseInt(battle.type) === 3)
+			let timezone = words.slice(1).join(" ");
+			var current = new Date();
 			if (data.length === 0) throw "No ohb data returned!"
 			data.forEach(battle => {
+			    let times = battle.period_end_time_left.split(" ");
+			    let hours = parseInt(times[0].slice(0, -1));
+			    let minutes = parseInt(times[1].slice(0, -1));
+			    let seconds = parseInt(times[2].slice(0, -1));
+			    while (current.getUTCSeconds() + seconds > 59) {
+			        minutes += 1;
+			        seconds -= 60;
+			    };
+			    while (current.getUTCMinutes() + minutes > 59) {
+			        hours += 1;
+			        minutes -= 60;
+			    };
+			    if (current.getUTCHours() + hours > 23) hours -= 24;
 				let ohb_info = "OHB \"" + battle.title + "\" :: ";
-				if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left;
-				if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left;
+				if (timezone == "") {
+				    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours) + ":" + (current.getUTCMinutes() + minutes) + ")";
+				    if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours) + ":" + (current.getUTCMinutes() + minutes) + ")";
+				}
+				if (timezone.startsWith("utc") || timezone.startsWith("gmt")) {
+				    let addToDate = parseInt(timezone.slice(3))
+				    if (battle.period == 'warmup') ohb_info += "Starting in: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours + addToDate) + ":" + (current.getUTCMinutes() + minutes) + ")";
+				    if (battle.period == 'entry') ohb_info += "Time left: " + battle.period_end_time_left + " (" + (current.getUTCHours() + hours + addToDate) + ":" + (current.getUTCMinutes() + minutes) + ")";
+				}
 				if (battle.period == 'vote') ohb_info += "Vorting Tiem";
 				ohb_info += " :: Format: " + battle.format_tokens[0];
 				ohb_info += " :: <" + battle.profile_url.match(url_regex) + "> ";

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -489,10 +489,31 @@ module.exports = {
 	 */
 	
 	roll: (info, words) => {
-	    	let number = words.slice(1).join(" ");
-	    	if (number == "") number = 10;
-	    	let chat_text = `${info.from} rolls ` + (Math.floor(Math.random() * number) + 1) + "!"
-	    	bot.say(info.channel, `${chat_text}`)
+	    	let dice_notation = words.slice(1).join(" ").toLowerCase();
+	    	if (dice_notation == "") dice_notation = "d10";
+	    
+	    	if (dice_notation.startsWith("d")) {var dice_amount = 1}
+	    	else {var dice_amount = parseInt(dice_notation.split("d")[0])};
+	    
+	    	let sum = 0;
+	    
+	    	let dice_amount_length = dice_amount.toString().length;
+	    	if (dice_notation.includes("+")) {
+	        	sum += parseInt(dice_notation.split("+")[1]);
+	        	var number_limit = parseInt(dice_notation.split("+")[0].slice(dice_amount_length));
+	    	}	
+	    	else if (dice_notation.includes("-")) {
+	        	sum -= parseInt(dice_notation.split("-")[1]);
+	        	var number_limit = parseInt(dice_notation.split("-")[0].slice(dice_amount_length));
+	    	}
+	    	else {
+	        	var number_limit = parseInt(dice_notation.slice(dice_amount_length));
+	    	};
+	    
+	    	for (let i = 0; i < dice_amount; i++) {sum += Math.floor(Math.random() * number_limit) + 1};
+	    	let chat_text = `${info.from} rolls ` + sum + "!";
+	    
+	    	bot.say(info.channel, `${chat_text}`);
 	},
 
 	/**

--- a/bot_modules/irc_commands.js
+++ b/bot_modules/irc_commands.js
@@ -484,57 +484,61 @@ module.exports = {
 	},
 	
 	/**
-	 *	roll
+	 *  roll
 	 *
 	 */
-	
 	roll: (info, words) => {
 	    	let dice_notation = words.slice(1).join(" ").toLowerCase();
-	    	if (dice_notation == "") dice_notation = "1d10";
-	    
-	    	if (dice_notation.startsWith("d")) {dice_notation = "1" + dice_notation; var dice_amount = 1}
-	    	else {var dice_amount = parseInt(dice_notation.split("d")[0])};
-	    
-	    	let sum = 0;
-	    
-	    	var dice_amount_length = dice_amount.toString().length + 1;
-	    
-	    	if (dice_notation.includes("+")) {
-	        	let add_to_sum = dice_notation.split("+")[1];
+	    	if (dice_notation.includes("d")) {
+	        	if (dice_notation == "") dice_notation = "1d10";
 	        
-	        	if (add_to_sum.includes("d")) {
-	            		if (add_to_sum.startsWith("d")) add_to_sum = "1" + add_to_sum;
-	            		let subdice_amount = parseInt(add_to_sum.split("d")[0]);;
-	            		let subnumber_limit = parseInt(add_to_sum.split("d")[1]);
-	            		for (let i = 0; i < subdice_amount; i++) {sum += Math.floor(Math.random() * subnumber_limit) + 1};
+	        	if (dice_notation.startsWith("d")) {dice_notation = "1" + dice_notation; var dice_amount = 1}
+	        	else {var dice_amount = parseInt(dice_notation.split("d")[0])};
+	        
+	        	let sum = 0;
+	        
+	        	var dice_amount_length = dice_amount.toString().length + 1;
+	        
+	        	if (dice_notation.includes("+")) {
+	            		let add_to_sum = dice_notation.split("+")[1];
+	            
+	           		if (add_to_sum.includes("d")) {
+	                		if (add_to_sum.startsWith("d")) add_to_sum = "1" + add_to_sum;
+	                		let subdice_amount = parseInt(add_to_sum.split("d")[0]);;
+	                		let subnumber_limit = parseInt(add_to_sum.split("d")[1]);
+	                		for (let i = 0; i < subdice_amount; i++) {sum += Math.floor(Math.random() * subnumber_limit) + 1};
+	            		}
+	            		else {
+	                		sum += parseInt(add_to_sum);
+	            		};
+	            
+	            		var number_limit = parseInt(dice_notation.split("+")[0].slice(dice_amount_length));
+	        	}
+	        	else if (dice_notation.includes("-")) {
+	            		let subtract_to_sum = dice_notation.split("-")[1];
+	            
+	            		if (subtract_to_sum.includes("d")) {
+	                		if (subtract_to_sum.startsWith("d")) subtract_to_sum = "1" + subtract_to_sum;
+	                		let subdice_amount = parseInt(subtract_to_sum.split("d")[0]);
+	                		let subnumber_limit = parseInt(subtract_to_sum.split("d")[1]);
+	                		for (let i = 0; i < subdice_amount; i++) {sum -= Math.floor(Math.random() * subnumber_limit) + 1};
+	            		}
+	           		else {
+	                		sum += parseInt(subtract_to_sum);
+	            		};
+	            
+	            		var number_limit = parseInt(dice_notation.split("-")[0].slice(dice_amount_length));
 	        	}
 	        	else {
-	            		sum += parseInt(add_to_sum);
+	            		var number_limit = parseInt(dice_notation.slice(dice_amount_length));
 	        	};
 	        
-	        	var number_limit = parseInt(dice_notation.split("+")[0].slice(dice_amount_length));
-	    	}
-	    	else if (dice_notation.includes("-")) {
-	        	let subtract_to_sum = dice_notation.split("-")[1];
-	        
-	        	if (subtract_to_sum.includes("d")) {
-	            		if (subtract_to_sum.startsWith("d")) subtract_to_sum = "1" + subtract_to_sum;
-	            		let subdice_amount = parseInt(subtract_to_sum.split("d")[0]);
-	            		let subnumber_limit = parseInt(subtract_to_sum.split("d")[1]);
-	            		for (let i = 0; i < subdice_amount; i++) {sum -= Math.floor(Math.random() * subnumber_limit) + 1};
-	        	}
-	        	else {
-	            		sum += parseInt(subtract_to_sum);
-	        	};
-	        
-	        	var number_limit = parseInt(dice_notation.split("-")[0].slice(dice_amount_length));
+	        	for (let i = 0; i < dice_amount; i++) {sum += Math.floor(Math.random() * number_limit) + 1};
+	        	var chat_text = `${info.from} rolls ` + sum + "!";
 	    	}
 	    	else {
-	        	var number_limit = parseInt(dice_notation.slice(dice_amount_length));
+	    		var chat_text = `${info.from} rolls ` + (Math.floor(Math.random() * parseInt(dice_notation)) + 1) + "!";
 	    	};
-	    
-	    	for (let i = 0; i < dice_amount; i++) {sum += Math.floor(Math.random() * number_limit) + 1};
-	    	let chat_text = `${info.from} rolls ` + sum + "!";
 	    
 	    	bot.say(info.channel, `${chat_text}`);
 	},


### PR DESCRIPTION
Uhh, yeah. When I added the roll command, I removed the basic rolling and left just dice notation, but I didn't say anything about this on the PR, thinking that this would be discovered. Because I hadn't explained this, the feature was, shortly after adding, removed because it always returned NaN. So, here is basic rolling and dice notation.

Example:
```
<viraxor> !roll 100
<BotB2_tes> viraxor rolls 93!
<viraxor> !roll -100
<BotB2_tes> viraxor rolls -58!
<viraxor> !roll d10
<BotB2_tes> viraxor rolls 4!
<viraxor> !roll 2d20
<BotB2_tes> viraxor rolls 36!
<viraxor> !roll 4d40+2d17
<BotB2_tes> viraxor rolls 98!
<viraxor> !roll 30d28-99d95
<BotB2_tes> viraxor rolls -4100! 
```