### PR TITLE
Set up pre-push hook to run lint command

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "botb_irc_bot",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -12,7 +13,8 @@
         "irc": "^0.5.0"
       },
       "devDependencies": {
-        "eslint": "^8.33.0"
+        "eslint": "^8.33.0",
+        "husky": "^8.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -793,6 +795,21 @@
         "npm": ">=1.3.7"
       }
     },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/iconv": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/iconv/-/iconv-2.2.3.tgz",
@@ -861,9 +878,7 @@
       "resolved": "https://registry.npmjs.org/irc/-/irc-0.5.2.tgz",
       "integrity": "sha1-NxT0doNlqW0LL3dryRFmvrJGS7w=",
       "dependencies": {
-        "iconv": "~2.2.1",
-        "irc-colors": "^1.1.0",
-        "node-icu-charset-detector": "~0.2.0"
+        "irc-colors": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -2214,6 +2229,12 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
+    },
+    "husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true
     },
     "iconv": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "irc": "^0.5.0"
   },
   "devDependencies": {
-    "eslint": "^8.33.0"
+    "eslint": "^8.33.0",
+    "husky": "^8.0.0"
   },
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "start": "node bot.js"
+    "start": "node bot.js",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
this PR installs a dev dependency called [husky](https://www.npmjs.com/package/husky) which automatically configures git hooks for new contributors.

it also adds a pre-push git hook that runs `npm run lint` and prevents the push if there are linter errors.

note: people with an existing clone of the repository will not have this git hook. they need to run `npm install` for this system to be configured.