### PR TITLE
add total kudos to !kudosamount

### DIFF
--- a/bot_modules/irc_kudos.js
+++ b/bot_modules/irc_kudos.js
@@ -86,10 +86,14 @@ module.exports = {
 		words.shift();
 		let count = 0;
 		let amount = parseInt(words);
-		if (isNaN(amount)) return 'yer numb0r is borked!!! D=';
 		let kudos = ram.get('kudos');
-		for (let prop in kudos) if (kudos[prop] === amount) count++;
-		return `There are currently ${count} different keys with ${amount} kudos.`;
+		if (isNaN(amount)) {
+			count = Object.keys(kudos).length;
+			return `There are currently ${count} different keys.`;
+		} else {
+			for (let prop in kudos) if (kudos[prop] === amount) count++;
+			return `There are currently ${count} different keys with ${amount} kudos.`;
+		}
 	},
 
 	minus: words => process(words, 'minus'),


### PR DESCRIPTION
says the number of total keys if no number is specified in the command

```
<viraxor> !kudosamount
<BotB_test_bot> There are currently 2348738 different keys.
<viraxor> !kudosamount 0
<BotB_test_bot> There are currently 3009 different keys with 0 kudos.
```